### PR TITLE
Able to choose log level at the command line.

### DIFF
--- a/mannhunter/cli.py
+++ b/mannhunter/cli.py
@@ -19,9 +19,13 @@ import mannhunter.core
 @click.option(
     '-P', '--port', envvar='RIEMANN_PORT', type=click.INT, default=5555,
     help="Riemann server port")
-def main(config, host, port):
+@click.option(
+    '-l', '--loglevel', default='info',
+    type=click.Choice(['info', 'warning', 'debug', 'error', 'critical']),
+    help="The level to log at")
+def main(config, host, port, loglevel):
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=getattr(logging, loglevel.upper()),
         format='%(asctime)s:%(levelname)s:%(name)s:%(message)s')
 
     return mannhunter.core.Mannhunter.configure(

--- a/mannhunter/cli.py
+++ b/mannhunter/cli.py
@@ -36,7 +36,8 @@ def main(config, host, port, loglevel, stats):
     if stats:
         for service in m.stats():
             if service['mem_limit'] is not None:
-                print "{0} {1} / {2}  ({3:.2%})".format(service['name'],
+                print "{0} {1} / {2}  ({3:.2%})".format(
+                    service['name'],
                     mannhunter.core.sizeof_fmt(service['mem_used']),
                     mannhunter.core.sizeof_fmt(service['mem_limit']),
                     float(service['mem_used']) / float(service['mem_limit']))

--- a/mannhunter/core.py
+++ b/mannhunter/core.py
@@ -45,7 +45,10 @@ class Interval(object):
         return self
 
     def __exit__(self, *exc_info):
-        time.sleep(self.interval - (time.time() - self.last))
+        interval = self.interval - (time.time() - self.last)
+        if interval > 0:
+            time.sleep(interval)
+
         self.last = time.time()
         return True
 

--- a/mannhunter/core.py
+++ b/mannhunter/core.py
@@ -50,7 +50,6 @@ class Interval(object):
             time.sleep(interval)
 
         self.last = time.time()
-        return True
 
 
 class MannhunterConfigParser(ConfigParser.RawConfigParser):
@@ -160,7 +159,6 @@ class Mannhunter(object):
     def __exit__(self, *exc_info):
         if self.riemann is not None:
             self.riemann.__exit__(*exc_info)
-        return self
 
     @property
     def supervisor(self):


### PR DESCRIPTION
Not usually happy using getattr but the choices are limited by `click.Choice` so it is safe.  The [Python docs](https://docs.python.org/2/howto/logging.html#logging-to-a-file) seem to say that is the way to turn a string to a loglevel.

I have added the ability to print out some stats of the current memory usage of the services being limited.
